### PR TITLE
strip line end whitespace

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file. See [conven
 
 
 ---
+## [0.6.1](https://github.com/belingud/httpie-websockets/compare/v0.6.0..v0.6.1) - 2024-09-14
+
+### 🐛 Bug Fixes
+
+- Correct newline handling in stdin read - ([20d8285](https://github.com/belingud/httpie-websockets/commit/20d82859415a81829ec67303be9560da8c622ac2)) - belingud
+
+### 🧪 Testing
+
+- Refactor proxy test setup and add end-with-whitespace tests - ([d580559](https://github.com/belingud/httpie-websockets/commit/d5805590dd584f4e34501e235813bc34e29e431c)) - belingud
+
+### ⚙️ Miscellaneous Tasks
+
+- Update pyproject.toml and pyrightconfig.json - ([d7d2077](https://github.com/belingud/httpie-websockets/commit/d7d207761e29189e325a30a33c131e8b09b52e17)) - belingud
+- Update CHANGELOG and scripts for new features and fixes - ([1e5048e](https://github.com/belingud/httpie-websockets/commit/1e5048ee16e5b0275e3fac9c26c7f2c1385dee98)) - belingud
+
+
+---
 ## [0.6.0](https://github.com/belingud/httpie-websockets/compare/v0.5.4..v0.6.0) - 2024-09-13
 
 ### ⛰️  Features

--- a/httpie_websockets.py
+++ b/httpie_websockets.py
@@ -22,7 +22,7 @@ from requests.models import PreparedRequest, Response
 from requests.structures import CaseInsensitiveDict
 from websocket import ABNF, STATUS_ABNORMAL_CLOSED
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "belingud"
 __license__ = "MIT"
 

--- a/httpie_websockets.py
+++ b/httpie_websockets.py
@@ -50,7 +50,7 @@ if platform.system().lower() == "windows":
                     print()
                     break
                 input_buffer += char
-            return input_buffer.rstrip("\n")
+            return input_buffer.rstrip("\n ")
         return None
 else:
     import select
@@ -58,7 +58,7 @@ else:
     def _read_stdin():
         r, _, _ = select.select([sys.stdin], [], [], 1)
         if sys.stdin in r:
-            return sys.stdin.readline().rstrip("\n")
+            return sys.stdin.readline().rstrip("\n ")
         return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 name = "httpie-websockets"
 version = "0.6.0"
 description = "Websocket plugin for httpie"
-authors = [
-    { name = "belingud", email = "1170202353@qq.com" }
-]
+authors = [{ name = "belingud", email = "1170202353@qq.com" }]
 dependencies = [
     "requests>=2.31.0",
     "httpie>=3.2.3",
@@ -31,7 +29,7 @@ classifiers = [
     "Topic :: System :: Networking",
     "Topic :: Terminals",
     "Topic :: Text Processing",
-    "Topic :: Utilities"
+    "Topic :: Utilities",
 ]
 
 [project.urls]
@@ -51,7 +49,7 @@ httpie_websockets = "httpie_websockets:WebsocketSPlugin"
 httpie_websocket = "httpie_websockets:WebsocketPlugin"
 
 [tool.pytest.ini_options]
-addopts = "-rsxX -l --tb=short --strict"
+addopts = "-rsxX -s -l --tb=short --strict"
 testpaths = ["tests/"]
 python_files = ["test*.py"]
 markers = ["skipif: conditionally skip tests"]
@@ -63,7 +61,15 @@ distribution = true
 profile = "black"
 
 [tool.pdm.build]
-excludes = ["tests", ".idea/", ".vscode", ".venv", "pdm.lock", ".gitignore", "var"]
+excludes = [
+    "tests",
+    ".idea/",
+    ".vscode",
+    ".venv",
+    "pdm.lock",
+    ".gitignore",
+    "var",
+]
 includes = ["httpie_websockets.py"]
 
 [tool.pdm.lock]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "httpie-websockets"
-version = "0.6.0"
+version = "0.6.1"
 description = "Websocket plugin for httpie"
 authors = [{ name = "belingud", email = "1170202353@qq.com" }]
 dependencies = [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -50,7 +50,6 @@ def write_changelog(changelog_content: str) -> None:
         # note -> All notable changes to this project will xxx
         tmp_f.write(f.readline())
         tmp_f.write(f.readline())
-        tmp_f.write("\n")
 
         while True:
             cc_content = cc_container.read(1024 * 1024)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from unittest.mock import Mock
 from urllib.parse import urlparse
@@ -16,12 +17,14 @@ class MockTask:
 
 @lru_cache(maxsize=3)
 def get_proxy(limit=10, timeout=5000):
-    url = (
-        "https://api.proxyscrape.com/v3/free-proxy-list/get?"
-        f"request=getproxies&country=hk&skip=0&proxy_format=protocolipport&format=json&limit={limit}&"
-        f"anonymity=Elite&timeout={timeout}"
-    )
+    url = "https://raw.githubusercontent.com/proxifly/free-proxy-list/main/proxies/countries/CN/data.txt"
     resp = requests.get(url)
     resp.raise_for_status()
-    data = resp.json()
-    return [urlparse(proxy["proxy"]) for proxy in data['proxies']]
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)
+    os.environ.pop("ALL_PROXY", None)
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("https_proxy", None)
+    os.environ.pop("all_proxy", None)
+    data = resp.text.splitlines()
+    return [urlparse(proxy) for proxy in data]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,7 @@
 # conftest.py
-
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
 def docker_compose():
-    print("++++++++++++++++++++++++++starting ws container+++++++++++++++++++++++++++++")
-
     yield
-
-    print("++++++++++++++++++++++++++stopping ws container+++++++++++++++++++++++++++++")

--- a/tests/test__connect.py
+++ b/tests/test__connect.py
@@ -31,7 +31,6 @@ def test_connect_with_proxy():
     if not all_proxies:
         pytest.skip("[SKIP] test function: test_connect_with_proxy. No proxy available from API.")
     choice_one = random.choice(all_proxies)
-    print(all_proxies[0].geturl())
     _proxy = {choice_one.scheme: choice_one.geturl()}
     try:
         adapter._connect(request, proxies=_proxy)

--- a/tests/test_read_stdin.py
+++ b/tests/test_read_stdin.py
@@ -9,15 +9,38 @@ from httpie_websockets import _read_stdin
 IS_WINDOWS = platform.system().lower() == "windows"
 
 
-@pytest.mark.skipif(not IS_WINDOWS, reason="Requires Windows platform")
+@pytest.mark.skipif(not IS_WINDOWS, reason="Requires Windows platform: test_read_stdin_windows")
 def test_read_stdin_windows(monkeypatch):
     with patch("msvcrt.kbhit", return_value=True):
         with patch("msvcrt.getwche", side_effect=list("test_input") + ["\r"]):
             assert _read_stdin() == "test_input"
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="Requires non-Windows platform")
+@pytest.mark.skipif(IS_WINDOWS, reason="Requires non-Windows platform: test_read_stdin_non_windows")
 def test_read_stdin_non_windows(monkeypatch):
     with patch("select.select", return_value=([sys.stdin], [], [])):
         with patch("sys.stdin.readline", return_value="test_input\n"):
             assert _read_stdin() == "test_input"
+
+
+@pytest.mark.skipif(
+    IS_WINDOWS,
+    reason="Requires non-Windows platform: test_read_stdin_nonwindows_end_with_whitespace",
+)
+def test_read_stdin_nonwindows_end_with_whitespace(monkeypatch):
+    with (
+        patch("select.select", return_value=([sys.stdin], [], [])),
+        patch("sys.stdin.readline", return_value="test_input\n "),
+    ):
+        assert _read_stdin() == "test_input"
+
+
+@pytest.mark.skipif(
+    not IS_WINDOWS, reason="Requires Windows platform: test_read_stdin_windows_end_with_whitespace"
+)
+def test_read_stdin_windows_end_with_whitespace(monkeypatch):
+    with (
+        patch("msvcrt.kbhit", return_value=([sys.stdin], [], [])),
+        patch("msvcrt.getwche", return_value=list("test_input\n ")),
+    ):
+        assert _read_stdin() == "test_input"


### PR DESCRIPTION
- **feat: Remove deprecated Makefile and Messages Download functionality**
- **feat: Update changelog formatting and parser configuration**
- **feat: Add changelog generation script**
- **feat: Add multiple line input support, escape odd backslashes at the end-of-line**
- **docs: Update README and CHANGELOG for new features and fixes**
- **Bump version: 0.5.4 → 0.6.0**
- **chore: Update CHANGELOG and scripts for new features and fixes**
- **fix: Correct newline handling in stdin read**
- **chore: Update pyproject.toml and pyrightconfig.json**
- **test: Refactor proxy test setup and add end-with-whitespace tests**
- **Bump version: 0.6.0 → 0.6.1**
- **docs: Update CHANGELOG for v0.6.1 release**
